### PR TITLE
Fixed a bug where the target environment warning would never appear.

### DIFF
--- a/1-regexes/a/test_lexer.sh
+++ b/1-regexes/a/test_lexer.sh
@@ -46,7 +46,7 @@ else
     grep -q "Ubuntu 16.04" <(echo $RELEASE)
     FOUND=$?
 
-    if [[ $? -ne 0 ]]; then
+    if [[ $FOUND -ne 0 ]]; then
         echo ""
         echo "Warning: This appears not to be the target environment"
         echo "         Make sure you do a final run on a lab machine or an Ubuntu VM"


### PR DESCRIPTION
Return code was being set on assignment so would always be 0.

I'm guessing a simple typo, this should have fixed it.